### PR TITLE
chore: bump version to 8.6.10 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "uniquegen",
-    "version": "8.6.9",
+    "version": "8.6.10",
     "description": "uniquegen is an package for Node.js projects, enabling the generation of random numbers and words. It offers flexibility and ease of use, making it a valuable tool for developers.",
     "main": "Service/uniquegen.js",
     "types": "Service/uniquegen.d.ts",


### PR DESCRIPTION
This pull request makes a minor update to the `uniquegen` package version in the `package.json` file, incrementing it from `8.6.9` to `8.6.10`.