### PR TITLE
fix: update repository URLs to reflect new ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,5 @@ Click the "Fork" button in the upper right corner of the repository to create yo
 Clone your forked repository to your local machine:
 
 ```bash
-git clone https://github.com/AnkanSaha/uniquegen.git
+git clone https://github.com/nexoral/uniquegen.git
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ UniqueGen is an package for Node.js, It enables generating random numbers, alpha
 [![npm version](https://badge.fury.io/js/uniquegen.svg)](https://badge.fury.io/js/uniquegen)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm downloads](https://img.shields.io/npm/dt/uniquegen.svg?style=flat-square)](https://www.npmjs.com/package/uniquegen)
-[![CodeQL](https://github.com/AnkanSaha/uniquegen/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/AnkanSaha/uniquegen/actions/workflows/github-code-scanning/codeql)
+[![CodeQL](https://github.com/nexoral/uniquegen/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nexoral/uniquegen/actions/workflows/github-code-scanning/codeql)
 
 # Features
 
@@ -144,7 +144,7 @@ randomMixed(); // it will generate a random mixed ID of length 10 with all alpha
 
 # Contributing
 
-[Ankan Saha]("github.com/AnkanSaha")
+[Ankan Saha]("github.com/nexoral")
 [Priya Ghosh]("https://www.npmjs.com/~priya_ghosh")
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,59 +1,59 @@
 {
-    "name": "uniquegen",
-    "version": "8.6.10",
-    "description": "uniquegen is an package for Node.js projects, enabling the generation of random numbers and words. It offers flexibility and ease of use, making it a valuable tool for developers.",
-    "main": "Service/uniquegen.js",
-    "types": "Service/uniquegen.d.ts",
-    "scripts": {
-        "build": "npm test && tsc",
-        "prepare": "npm run build",
-        "test": "npm run lint",
-        "lint": "tslint -c tslint.json 'src/**/*.ts'"
-    },
-    "keywords": [
-        "UniqueGen",
-        "Unique",
-        "Gen",
-        "Random",
-        "UUID",
-        "Programming Languages",
-        "Utilities",
-        "Random",
-        "Generator"
-    ],
-    "author": "Ankan Saha",
-    "license": "MIT",
-    "displayName": "UniqueGen",
-    "icon": "https://th.bing.com/th/id/OIP.mp8SPXPOGVDGGvKVnwyoiQHaHa?pid=ImgDet&rs=1",
-    "publisher": "Ankan Saha",
-    "maintainers": [
-        "Ankan Saha",
-        "Priya Ghosh"
-    ],
-    "categories": [
-        "Utilities",
-        "Random",
-        "UUID",
-        "Unique",
-        "Gen",
-        "UniqueGen",
-        "UUID",
-        "Programming Languages"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/AnkanSaha/uniquegen.git"
-    },
-    "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/AnkanSaha"
-    },
-    "devDependencies": {
-        "tslint": "^6.1.3",
-        "typescript": "^5.2.2"
-    },
-    "sponsor": {
-        "type": "git",
-        "url": "https://github.com/sponsors/AnkanSaha"
-    }
+  "name": "uniquegen",
+  "version": "8.6.11",
+  "description": "uniquegen is an package for Node.js projects, enabling the generation of random numbers and words. It offers flexibility and ease of use, making it a valuable tool for developers.",
+  "main": "Service/uniquegen.js",
+  "types": "Service/uniquegen.d.ts",
+  "scripts": {
+    "build": "npm test && tsc",
+    "prepare": "npm run build",
+    "test": "npm run lint",
+    "lint": "tslint -c tslint.json 'src/**/*.ts'"
+  },
+  "keywords": [
+    "UniqueGen",
+    "Unique",
+    "Gen",
+    "Random",
+    "UUID",
+    "Programming Languages",
+    "Utilities",
+    "Random",
+    "Generator"
+  ],
+  "author": "Ankan Saha",
+  "license": "MIT",
+  "displayName": "UniqueGen",
+  "icon": "https://th.bing.com/th/id/OIP.mp8SPXPOGVDGGvKVnwyoiQHaHa?pid=ImgDet&rs=1",
+  "publisher": "Ankan Saha",
+  "maintainers": [
+    "Ankan Saha",
+    "Priya Ghosh"
+  ],
+  "categories": [
+    "Utilities",
+    "Random",
+    "UUID",
+    "Unique",
+    "Gen",
+    "UniqueGen",
+    "UUID",
+    "Programming Languages"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nexoral/uniquegen.git"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/AnkanSaha"
+  },
+  "devDependencies": {
+    "tslint": "^6.1.3",
+    "typescript": "^5.2.2"
+  },
+  "sponsor": {
+    "type": "git",
+    "url": "https://github.com/sponsors/AnkanSaha"
+  }
 }


### PR DESCRIPTION
This pull request updates repository references throughout the project to point to the new GitHub organization, `nexoral`, instead of the previous owner, `AnkanSaha`. It also bumps the package version. These changes help ensure consistency across documentation, configuration, and metadata.

Repository reference updates:

* Updated the repository URL in `package.json` to `https://github.com/nexoral/uniquegen.git`.
* Changed the clone URL in the contributing guide (`CONTRIBUTING.md`) to use the new organization.
* Updated the CodeQL badge in `README.md` to point to the new repository location.
* Changed contributor profile link for Ankan Saha in `README.md` to the new organization.

Version bump:

* Incremented the package version from `8.6.10` to `8.6.11` in `package.json`.